### PR TITLE
Do not merge: intent to allow relicensing of repository to Apache 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021 Eric Daniels
+Copyright 2023 Viam, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
As the upstream owner of gostream, I'm creating (and closing) this pull request to publicly state that I allow Viam, Inc. to relicense this repository to the Apache 2.0 license