### PR TITLE
update go.mod/go.sum

### DIFF
--- a/cmd/stream_audio/main.go
+++ b/cmd/stream_audio/main.go
@@ -20,8 +20,8 @@ import (
 	goutils "go.viam.com/utils"
 	hopus "gopkg.in/hraban/opus.v2"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec/opus"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec/opus"
 )
 
 func main() {

--- a/cmd/stream_av/main.go
+++ b/cmd/stream_av/main.go
@@ -12,9 +12,9 @@ import (
 	"go.uber.org/multierr"
 	goutils "go.viam.com/utils"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec/opus"
-	"github.com/edaniels/gostream/codec/vpx"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec/opus"
+	"github.com/viamrobotics/gostream/codec/vpx"
 )
 
 func main() {

--- a/cmd/stream_video/main.go
+++ b/cmd/stream_video/main.go
@@ -11,9 +11,9 @@ import (
 	"go.uber.org/multierr"
 	goutils "go.viam.com/utils"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec/vpx"
-	"github.com/edaniels/gostream/codec/x264"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec/vpx"
+	"github.com/viamrobotics/gostream/codec/x264"
 )
 
 func main() {

--- a/codec/mmal/encoder.go
+++ b/codec/mmal/encoder.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"image"
 
-	ourcodec "github.com/edaniels/gostream/codec"
+	ourcodec "github.com/viamrobotics/gostream/codec"
 
 	"github.com/edaniels/golog"
 	"github.com/pion/mediadevices/pkg/codec"

--- a/codec/mmal/utils.go
+++ b/codec/mmal/utils.go
@@ -1,8 +1,8 @@
 package mmal
 
 import (
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec"
 
 	"github.com/edaniels/golog"
 )

--- a/codec/opus/encoder.go
+++ b/codec/opus/encoder.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pion/mediadevices/pkg/wave"
 	"go.viam.com/utils"
 
-	ourcodec "github.com/edaniels/gostream/codec"
+	ourcodec "github.com/viamrobotics/gostream/codec"
 )
 
 type encoder struct {

--- a/codec/opus/utils.go
+++ b/codec/opus/utils.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/edaniels/golog"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec"
 )
 
 // DefaultStreamConfig configures Opus as the audio encoder for a stream.

--- a/codec/vpx/encoder.go
+++ b/codec/vpx/encoder.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pion/mediadevices/pkg/codec/vpx"
 	"github.com/pion/mediadevices/pkg/prop"
 
-	ourcodec "github.com/edaniels/gostream/codec"
+	ourcodec "github.com/viamrobotics/gostream/codec"
 )
 
 type encoder struct {

--- a/codec/vpx/utils.go
+++ b/codec/vpx/utils.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/edaniels/golog"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec"
 )
 
 // DefaultStreamConfig configures vpx as the encoder for a stream.

--- a/codec/x264/encoder.go
+++ b/codec/x264/encoder.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pion/mediadevices/pkg/codec/x264"
 	"github.com/pion/mediadevices/pkg/prop"
 
-	ourcodec "github.com/edaniels/gostream/codec"
+	ourcodec "github.com/viamrobotics/gostream/codec"
 )
 
 type encoder struct {

--- a/codec/x264/utils.go
+++ b/codec/x264/utils.go
@@ -3,8 +3,8 @@ package x264
 import (
 	"github.com/edaniels/golog"
 
-	"github.com/edaniels/gostream"
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream"
+	"github.com/viamrobotics/gostream/codec"
 )
 
 // DefaultStreamConfig configures x264 as the encoder for a stream.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/edaniels/gostream
+module github.com/viamrobotics/gostream
 
 go 1.18
 

--- a/standalone_stream_server.go
+++ b/standalone_stream_server.go
@@ -18,7 +18,7 @@ import (
 	"goji.io"
 	"goji.io/pat"
 
-	streampb "github.com/edaniels/gostream/proto/stream/v1"
+	streampb "github.com/viamrobotics/gostream/proto/stream/v1"
 )
 
 // A StandaloneStreamServer is a convenience helper for solely streaming a series

--- a/stream.go
+++ b/stream.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pion/webrtc/v3"
 	"go.viam.com/utils"
 
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream/codec"
 )
 
 // A Stream is sink that accepts any image frames for the purpose

--- a/stream_config.go
+++ b/stream_config.go
@@ -3,7 +3,7 @@ package gostream
 import (
 	"github.com/edaniels/golog"
 
-	"github.com/edaniels/gostream/codec"
+	"github.com/viamrobotics/gostream/codec"
 )
 
 // A StreamConfig describes how a Stream should be managed.

--- a/stream_server.go
+++ b/stream_server.go
@@ -11,7 +11,7 @@ import (
 	"go.viam.com/utils"
 	"go.viam.com/utils/rpc"
 
-	streampb "github.com/edaniels/gostream/proto/stream/v1"
+	streampb "github.com/viamrobotics/gostream/proto/stream/v1"
 )
 
 // StreamAlreadyRegisteredError indicates that a stream has a name that is already registered on

--- a/video_test.go
+++ b/video_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pion/mediadevices/pkg/prop"
 	"go.viam.com/test"
 
-	"github.com/edaniels/gostream"
+	"github.com/viamrobotics/gostream"
 )
 
 func TestReaderClose(t *testing.T) {


### PR DESCRIPTION
- edaniels is only still referenced in `webrtc_track.go:16` in a TODO.
- The 1 commit from edaniels that I did not pull in just bumps mediadevices version. The version in this `go.mod` is higher so I didn't need to add that. 