### PR TITLE
RSDK-1121 Add benchmarks to gostream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,6 +253,7 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/term v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1423,6 +1423,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/media_test.go
+++ b/media_test.go
@@ -3,12 +3,13 @@ package gostream
 import (
 	"bytes"
 	"context"
-	"github.com/pion/mediadevices/pkg/prop"
-	"go.viam.com/test"
 	"image"
 	"image/png"
 	"os"
 	"testing"
+
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/test"
 )
 
 type imageSource struct {

--- a/media_test.go
+++ b/media_test.go
@@ -3,13 +3,12 @@ package gostream
 import (
 	"bytes"
 	"context"
+	"github.com/pion/mediadevices/pkg/prop"
+	"go.viam.com/test"
 	"image"
 	"image/png"
 	"os"
 	"testing"
-
-	"github.com/pion/mediadevices/pkg/prop"
-	"go.viam.com/test"
 )
 
 type imageSource struct {

--- a/perf/stream_test.go
+++ b/perf/stream_test.go
@@ -16,7 +16,7 @@ type reader struct {
 	limiter *rate.Limiter
 }
 
-func NewReader(fps float64) *reader {
+func newReader(fps float64) *reader {
 	limiter := rate.NewLimiter(rate.Limit(fps), 1)
 	return &reader{
 		img:     image.Image(image.Rect(0, 0, 0, 0)),
@@ -45,13 +45,13 @@ func stream(ctx context.Context, b *testing.B, s gostream.VideoStream) {
 
 const SecondNs = 1000000000.0 // second in nanoseconds
 
-func incrementAverage(avgOld float64, valNew float64, sizeNew float64) float64 {
+func incrementAverage(avgOld, valNew, sizeNew float64) float64 {
 	avgNew := (avgOld) + (valNew-avgOld)/sizeNew
 	return avgNew
 }
 
 func BenchmarkStream_30FPS(b *testing.B) {
-	r := NewReader(30)
+	r := newReader(30)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 
 	var avgNs float64
@@ -71,11 +71,11 @@ func BenchmarkStream_30FPS(b *testing.B) {
 		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
 	}
 
-	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+	b.ReportMetric(SecondNs/avgNs, "fps")
 }
 
 func BenchmarkStream_60FPS(b *testing.B) {
-	r := NewReader(60)
+	r := newReader(60)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 
 	var avgNs float64
@@ -95,14 +95,14 @@ func BenchmarkStream_60FPS(b *testing.B) {
 		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
 	}
 
-	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+	b.ReportMetric(SecondNs/avgNs, "fps")
 }
 
 func BenchmarkStream_30FPS_2Streams(b *testing.B) {
 	err := flag.Set("test.benchtime", "100x")
 	test.That(b, err, test.ShouldBeNil)
 
-	r := NewReader(30)
+	r := newReader(30)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -126,14 +126,14 @@ func BenchmarkStream_30FPS_2Streams(b *testing.B) {
 	}
 
 	cancel()
-	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+	b.ReportMetric(SecondNs/avgNs, "fps")
 }
 
 func BenchmarkStream_30FPS_3Streams(b *testing.B) {
 	err := flag.Set("test.benchtime", "100x")
 	test.That(b, err, test.ShouldBeNil)
 
-	r := NewReader(30)
+	r := newReader(30)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -158,5 +158,5 @@ func BenchmarkStream_30FPS_3Streams(b *testing.B) {
 	}
 
 	cancel()
-	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+	b.ReportMetric(SecondNs/avgNs, "fps")
 }

--- a/perf/stream_test.go
+++ b/perf/stream_test.go
@@ -3,13 +3,19 @@ package perf
 import (
 	"context"
 	"flag"
-	"github.com/viamrobotics/gostream"
-	"go.viam.com/test"
-	"golang.org/x/time/rate"
 	"image"
 	"testing"
 	"time"
+
+	"go.viam.com/test"
+	"golang.org/x/time/rate"
+
+	"github.com/viamrobotics/gostream"
 )
+
+func init() {
+	_ = flag.Set("test.benchtime", "100x")
+}
 
 type reader struct {
 	img     image.Image
@@ -99,9 +105,6 @@ func BenchmarkStream_60FPS(b *testing.B) {
 }
 
 func BenchmarkStream_30FPS_2Streams(b *testing.B) {
-	err := flag.Set("test.benchtime", "100x")
-	test.That(b, err, test.ShouldBeNil)
-
 	r := newReader(30)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -130,9 +133,6 @@ func BenchmarkStream_30FPS_2Streams(b *testing.B) {
 }
 
 func BenchmarkStream_30FPS_3Streams(b *testing.B) {
-	err := flag.Set("test.benchtime", "100x")
-	test.That(b, err, test.ShouldBeNil)
-
 	r := newReader(30)
 	s := gostream.NewEmbeddedVideoStreamFromReader(r)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/perf/stream_test.go
+++ b/perf/stream_test.go
@@ -1,0 +1,162 @@
+package perf
+
+import (
+	"context"
+	"flag"
+	"github.com/viamrobotics/gostream"
+	"go.viam.com/test"
+	"golang.org/x/time/rate"
+	"image"
+	"testing"
+	"time"
+)
+
+type reader struct {
+	img     image.Image
+	limiter *rate.Limiter
+}
+
+func NewReader(fps float64) *reader {
+	limiter := rate.NewLimiter(rate.Limit(fps), 1)
+	return &reader{
+		img:     image.Image(image.Rect(0, 0, 0, 0)),
+		limiter: limiter,
+	}
+}
+
+func (r *reader) Close(_ context.Context) error { return nil }
+func (r *reader) Read(_ context.Context) (image.Image, func(), error) {
+	_ = r.limiter.Wait(context.Background())
+	return r.img, func() {}, nil
+}
+
+func stream(ctx context.Context, b *testing.B, s gostream.VideoStream) {
+	b.Helper()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			_, _, err := s.Next(context.Background())
+			test.That(b, err, test.ShouldBeNil)
+		}
+	}
+}
+
+const SecondNs = 1000000000.0 // second in nanoseconds
+
+func incrementAverage(avgOld float64, valNew float64, sizeNew float64) float64 {
+	avgNew := (avgOld) + (valNew-avgOld)/sizeNew
+	return avgNew
+}
+
+func BenchmarkStream_30FPS(b *testing.B) {
+	r := NewReader(30)
+	s := gostream.NewEmbeddedVideoStreamFromReader(r)
+
+	var avgNs float64
+	var count int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+
+		b.StartTimer()
+		_, _, err := s.Next(context.Background())
+		b.StopTimer()
+
+		test.That(b, err, test.ShouldBeNil)
+		count++
+		elapsedNs := time.Since(start).Nanoseconds()
+		avgNs += (float64(elapsedNs) - avgNs) / float64(count)
+		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
+	}
+
+	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+}
+
+func BenchmarkStream_60FPS(b *testing.B) {
+	r := NewReader(60)
+	s := gostream.NewEmbeddedVideoStreamFromReader(r)
+
+	var avgNs float64
+	var count int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+
+		b.StartTimer()
+		_, _, err := s.Next(context.Background())
+		b.StopTimer()
+
+		test.That(b, err, test.ShouldBeNil)
+		count++
+		elapsedNs := time.Since(start).Nanoseconds()
+		avgNs += (float64(elapsedNs) - avgNs) / float64(count)
+		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
+	}
+
+	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+}
+
+func BenchmarkStream_30FPS_2Streams(b *testing.B) {
+	err := flag.Set("test.benchtime", "100x")
+	test.That(b, err, test.ShouldBeNil)
+
+	r := NewReader(30)
+	s := gostream.NewEmbeddedVideoStreamFromReader(r)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go stream(ctx, b, gostream.NewEmbeddedVideoStreamFromReader(r))
+
+	var avgNs float64
+	var count int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+
+		b.StartTimer()
+		_, _, err := s.Next(context.Background())
+		b.StopTimer()
+
+		test.That(b, err, test.ShouldBeNil)
+		count++
+		elapsedNs := time.Since(start).Nanoseconds()
+		avgNs += (float64(elapsedNs) - avgNs) / float64(count)
+		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
+	}
+
+	cancel()
+	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+}
+
+func BenchmarkStream_30FPS_3Streams(b *testing.B) {
+	err := flag.Set("test.benchtime", "100x")
+	test.That(b, err, test.ShouldBeNil)
+
+	r := NewReader(30)
+	s := gostream.NewEmbeddedVideoStreamFromReader(r)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go stream(ctx, b, gostream.NewEmbeddedVideoStreamFromReader(r))
+	go stream(ctx, b, gostream.NewEmbeddedVideoStreamFromReader(r))
+
+	var avgNs float64
+	var count int64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		start := time.Now()
+
+		b.StartTimer()
+		_, _, err := s.Next(context.Background())
+		b.StopTimer()
+
+		test.That(b, err, test.ShouldBeNil)
+		count++
+		elapsedNs := time.Since(start).Nanoseconds()
+		avgNs += (float64(elapsedNs) - avgNs) / float64(count)
+		avgNs = incrementAverage(avgNs, float64(elapsedNs), float64(count))
+	}
+
+	cancel()
+	b.ReportMetric(SecondNs/float64(avgNs), "fps")
+}


### PR DESCRIPTION
This PR creates benchmarks to test the performance of multiple streams. The results I've gotten are 
```
➜  perf git:(RSDK-2932) ✗ go test -v -run=XXX -bench=.
goos: linux
goarch: amd64
pkg: github.com/viamrobotics/gostream/perf
cpu: 12th Gen Intel(R) Core(TM) i7-1260P
BenchmarkStream_30FPS
BenchmarkStream_30FPS-16                     100          32855791 ns/op                29.99 fps
BenchmarkStream_60FPS
BenchmarkStream_60FPS-16                     100          16346751 ns/op                60.02 fps
BenchmarkStream_30FPS_2Streams
BenchmarkStream_30FPS_2Streams-16            100          65850590 ns/op                15.00 fps
BenchmarkStream_30FPS_3Streams
BenchmarkStream_30FPS_3Streams-16            100          98169577 ns/op                10.00 fps
PASS
ok      github.com/viamrobotics/gostream/perf   21.400s
```
Which is similar, but slightly worse than what I've seen calling `get_image` over and over in the SDK. This does appear to have a pretty significant performance degradation as the number of streams increase.