### PR TITLE
alignment fix for sync/atomic

### DIFF
--- a/media.go
+++ b/media.go
@@ -120,6 +120,7 @@ type mediaSource[T any, U any] struct {
 type producerConsumer[T any, U any] struct {
 	rootCancelCtx           context.Context
 	cancelCtx               context.Context
+	interestedConsumers     int64
 	cancelCtxMu             *sync.RWMutex
 	cancel                  func()
 	mimeType                string
@@ -130,7 +131,6 @@ type producerConsumer[T any, U any] struct {
 	producerCond            *sync.Cond
 	consumerCond            *sync.Cond
 	condMu                  *sync.RWMutex
-	interestedConsumers     int64
 	errHandlers             map[*mediaStream[T, U]][]ErrorHandler
 	listeners               int
 	stateMu                 sync.Mutex


### PR DESCRIPTION
## What
- change the position of the `interestedConsumers` field so it has 64-bit alignment within the struct
## Why
- on 32-bit ARM systems, sync/atomic operations will panic when they use this field
## Lint failure
The rdk repo will soon lint all dependencies for this error. Linter output:
```log
media.go:461:2: SA1027: address of non 64-bit aligned field interestedConsumers passed to sync/atomic.AddInt64 (staticcheck)
        atomic.AddInt64(&ms.prodCon.interestedConsumers, 1)
        ^
media.go:241:18: SA1027: address of non 64-bit aligned field interestedConsumers passed to sync/atomic.LoadInt64 (staticcheck)
                                        requests := atomic.LoadInt64(&pc.interestedConsumers)
                                                    ^
media.go:252:18: SA1027: address of non 64-bit aligned field interestedConsumers passed to sync/atomic.LoadInt64 (staticcheck)
                                                requests = atomic.LoadInt64(&pc.interestedConsumers)
                                                           ^
media.go:281:6: SA1027: address of non 64-bit aligned field interestedConsumers passed to sync/atomic.AddInt64 (staticcheck)
                                        atomic.AddInt64(&pc.interestedConsumers, -requests)
                                        ^
```